### PR TITLE
[DPA-963]: ci: override create tag logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ This repository serves as a central hub for shared protobuf definitions used acr
 Go applications can import only the necessary SDKs.
 
 ```bash
-$ go get github.com/smartcontractkit/chainlink-protos/job-distributor
-$ go get github.com/smartcontractkit/chainlink-protos/orchestrator
+$ go get github.com/smartcontractkit/chainlink-protos/job-distributor@v0.0.1
+$ go get github.com/smartcontractkit/chainlink-protos/orchestrator@v0.0.1
 ```
 
 ## Dependencies

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@chainlink/chainlink-protos",
   "private": true,
   "scripts": {
-    "ci:changeset:publish": "pnpm changeset publish",
+    "ci:changeset:publish": "sh ./scripts/tag-and-push.sh",
     "ci:changeset:version": "pnpm changeset version",
     "changesets": "pnpm changeset"
   },

--- a/scripts/tag-and-push.sh
+++ b/scripts/tag-and-push.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Function to create and push tag
+create_and_push_tag() {
+  local dir=$1
+  local package_json="$dir/package.json"
+  local service_name=$(grep '"name"' "$package_json" | sed -E 's/.*"name": *"([^"]+)".*/\1/' | sed 's/@chainlink\///')
+  local version=$(grep '"version"' "$package_json" | sed -E 's/.*"version": *"([^"]+)".*/\1/')
+
+  if [ "$service_name" != "null" ] && [ "$version" != "null" ]; then
+    local tag="${service_name}/v${version}"
+    if git rev-parse "$tag" >/dev/null 2>&1; then
+      echo "Tag $tag already exists. Skipping..."
+    else
+      echo "Creating tag: $tag"
+      git tag "$tag"
+      echo "Pushing tag: $tag"
+      git push origin "$tag"
+    fi
+  else
+    echo "Skipping $dir: Missing name or version in package.json"
+  fi
+}
+
+# Find all directories containing a package.json
+find . -name 'node_modules' -prune -o -path './package.json' -prune -o -name 'package.json' -exec dirname {} \; | while read -r dir; do
+  echo "processing $dir"
+  create_and_push_tag "$dir"
+done


### PR DESCRIPTION
The current [changeset tagging logic](https://github.com/changesets/changesets/blob/main/docs/command-line-options.md#tag) does not allow any sort of customization to the tag format.

Per the [go mod docs](https://go.dev/ref/mod#vcs-version), for monorepo, that tag has to be the format `<package-name>/v0.4.0`.

I created a script to override the tagging behavior of changesets.

### Testing: Tags have been created

I ran the script via the ci and it works

![Screenshot 2024-10-03 at 2 03 33 pm](https://github.com/user-attachments/assets/99e3e9fe-1fbc-4165-a630-48417d2f8f45)

We can fetch by 
```
go get github.com/smartcontractkit/chainlink-protos/job-distributor@v0.0.1
go get github.com/smartcontractkit/chainlink-protos/orchestrator@v0.0.1
```

**Once this PR is merged, i will delete the 2 previous tag that was created by changesets (which doesnt work for go mod)**

JIRA: https://smartcontract-it.atlassian.net/browse/DPA-963
