### PR TITLE
feat: add stale issues and PRs cleaning workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+# Workflow is triggered daily midnight UTC
+# A PR with more than 60 days of inactivity will be marked as stale
+# A PR that's stale for more than 7 days will be automatically closed
+# Issues are exempt from auto marking as stale but issues with manually added 'stale' label are eligible for auto closure after 7 days.
+# PRs with assignees are exempt from auto stale marking, it's the responsibility of the assignee to get the PR progressed either with review/merge or closure.
+name: Manage stale Issues and PRs
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Will be triggered every day at midnight UTC
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v9.0.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        exempt-all-pr-assignees: true
+        stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+        days-before-issue-stale: -1 # disables marking issues as stale automatically. Issues can still be marked as stale manually, in which the closure policy applies.


### PR DESCRIPTION
The workflow is triggered daily at midnight UTC.

A PR with more than 60 days of inactivity will be marked as stale.

A PR that's stale for more than 7 days will be automatically closed.

Issues are exempt from auto marking as stale but issues with manually added 'stale' label are eligible for auto closure after 7 days.

PRs with assignees are exempt from auto stale marking, it's the responsibility of the assignee to get the PR progressed either with review/merge or closure.