### PR TITLE
http trigger map to untyped api=false

### DIFF
--- a/cre/capabilities/networking/http/v1alpha/trigger.proto
+++ b/cre/capabilities/networking/http/v1alpha/trigger.proto
@@ -35,7 +35,5 @@ service HTTP {
     capability_id: "http-trigger@1.0.0-alpha"
   };
 
-  rpc Trigger(Config) returns (stream Payload) {
-    option (tools.generator.v1alpha.method) = {map_to_untyped_api: true};
-  }
+  rpc Trigger(Config) returns (stream Payload);
 }


### PR DESCRIPTION
for http trigger, remove `map-to-untyped-api` so that SDK can be generated