### PR TITLE
Add new rule for CRE. 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,4 @@
 /workflows/ @smartcontractkit/foundations @smartcontractkit/core
 /cre/ @smartcontractkit/keystone
 /storage-service/ @smartcontractkit/dev-services
+/.github/workflows/cre-validations.yml @smartcontractkit/keystone

--- a/.github/workflows/cre-validations.yml
+++ b/.github/workflows/cre-validations.yml
@@ -21,14 +21,14 @@ jobs:
         uses: smartcontractkit/tool-versions-to-env-action@v1.0.8
 
       - name: Run buf lint for cre
-        uses: bufbuild/buf-action@v1
+        uses: bufbuild/buf-action@c231a1aa9281e5db706c970f468f0744a37561fd #v1
         with:
           input: cre
           lint: true
           version: ${{ steps.tool-versions.outputs.buf_version }}
 
       - name: Run buf breaking for cre
-        uses: bufbuild/buf-action@v1
+        uses: bufbuild/buf-action@c231a1aa9281e5db706c970f468f0744a37561fd #v1
         with:
           input: cre
           breaking: true

--- a/.github/workflows/cre-validations.yml
+++ b/.github/workflows/cre-validations.yml
@@ -3,8 +3,6 @@ name: Lint and breaking check for cre
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-    paths:
-      - 'cre/**'
 
 permissions:
   contents: read
@@ -14,24 +12,38 @@ jobs:
   buf-cre:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Check if cre/ files were modified
+        id: changes
+        run: |
+          if git diff --name-only origin/main...HEAD | grep '^cre/'; then
+            echo "cre_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "cre_changed=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Set tool versions
+        if: steps.changes.outputs.cre_changed == 'true'
         id: tool-versions
-        uses: smartcontractkit/tool-versions-to-env-action@v1.0.8
+        uses: smartcontractkit/tool-versions-to-env-action@aabd5efbaf28005284e846c5cf3a02f2cba2f4c2 #v1.0.8
 
       - name: Run buf lint for cre
-        uses: bufbuild/buf-action@c231a1aa9281e5db706c970f468f0744a37561fd #v1
+        if: steps.changes.outputs.cre_changed == 'true'
+        uses: bufbuild/buf-action@c231a1aa9281e5db706c970f468f0744a37561fd # v1
         with:
           input: cre
           lint: true
           version: ${{ steps.tool-versions.outputs.buf_version }}
 
       - name: Run buf breaking for cre
-        uses: bufbuild/buf-action@c231a1aa9281e5db706c970f468f0744a37561fd #v1
+        if: steps.changes.outputs.cre_changed == 'true'
+        uses: bufbuild/buf-action@c231a1aa9281e5db706c970f468f0744a37561fd # v1
         with:
           input: cre
           breaking: true
           version: ${{ steps.tool-versions.outputs.buf_version }}
           exclude_paths: node_modules
 
+      - name: Skip buf checks — no cre/ changes
+        if: steps.changes.outputs.cre_changed == 'false'
+        run: echo "No changes to cre/ — skipping buf lint and breaking checks."

--- a/.github/workflows/cre-validations.yml
+++ b/.github/workflows/cre-validations.yml
@@ -1,0 +1,37 @@
+name: Lint and breaking check for cre
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - 'cre/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  buf-cre:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set tool versions
+        id: tool-versions
+        uses: smartcontractkit/tool-versions-to-env-action@v1.0.8
+
+      - name: Run buf lint for cre
+        uses: bufbuild/buf-action@v1
+        with:
+          input: cre
+          lint: true
+          version: ${{ steps.tool-versions.outputs.buf_version }}
+
+      - name: Run buf breaking for cre
+        uses: bufbuild/buf-action@v1
+        with:
+          input: cre
+          breaking: true
+          version: ${{ steps.tool-versions.outputs.buf_version }}
+          exclude_paths: node_modules
+

--- a/.github/workflows/regenerate-protobuf.yml
+++ b/.github/workflows/regenerate-protobuf.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: smartcontractkit/tool-versions-to-env-action@aabd5efbaf28005284e846c5cf3a02f2cba2f4c2 # v1.0.8
         id: tool-versions
-      - uses: bufbuild/buf-action@v1
+      - uses: bufbuild/buf-action@c231a1aa9281e5db706c970f468f0744a37561fd #v1
         with:
           breaking: ${{ github.event_name == 'pull_request' }}
           version: ${{ steps.tool-versions.outputs.buf_version }}

--- a/.github/workflows/regenerate-protobuf.yml
+++ b/.github/workflows/regenerate-protobuf.yml
@@ -3,6 +3,8 @@ name: Regenerate Protobuf Files
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+    paths-ignore:
+      - 'cre/**'
 
 permissions:
   id-token: write


### PR DESCRIPTION
I want this to be required, but buf-breaking in general cannot be blocking as new modules always break, since they didn't exist before. Also, I will add more rules at a later date that are CRE specific for validating the metadata