### PR TITLE
lowercase evm id

### DIFF
--- a/cre/capabilities/blockchain/evm/v1alpha/client.proto
+++ b/cre/capabilities/blockchain/evm/v1alpha/client.proto
@@ -186,7 +186,7 @@ service Client {
     labels: {
       // from https://github.com/smartcontractkit/chain-selectors/blob/main/selectors.yml
       // as a subset of the selectors supported on the CRE
-      key: "ChainSelector"
+      key: "chainselector"
       value: {
         uint64_label: {
           defaults: [


### PR DESCRIPTION
IDs aren't allowed to have uppercase characters, so this updates the proto to fix that