### PR TITLE
Update cre rule. 

### DIFF
--- a/.github/workflows/cre-validations.yml
+++ b/.github/workflows/cre-validations.yml
@@ -12,7 +12,18 @@ jobs:
   buf-cre:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v4 # v4.1.7
+
+      - name: Install buf CLI (v1.45.0, SHA bee67191e0a207d52b6c7f0ac9d3d1210898d2f9)
+        run: |
+          if ! command -v buf >/dev/null; then
+            echo "Installing buf CLI v1.45.0..."
+            curl -sSL https://github.com/bufbuild/buf/releases/download/v1.45.0/buf-$(uname -s)-$(uname -m) -o /usr/local/bin/buf
+            chmod +x /usr/local/bin/buf
+          else
+            echo "buf CLI already available."
+          fi
+
       - name: Check if cre/ files were modified
         id: changes
         run: |
@@ -25,25 +36,17 @@ jobs:
       - name: Set tool versions
         if: steps.changes.outputs.cre_changed == 'true'
         id: tool-versions
-        uses: smartcontractkit/tool-versions-to-env-action@aabd5efbaf28005284e846c5cf3a02f2cba2f4c2 #v1.0.8
+        uses: smartcontractkit/tool-versions-to-env-action@v1.0.8
 
       - name: Run buf lint for cre
         if: steps.changes.outputs.cre_changed == 'true'
-        uses: bufbuild/buf-action@c231a1aa9281e5db706c970f468f0744a37561fd # v1
-        with:
-          input: cre
-          lint: true
-          version: ${{ steps.tool-versions.outputs.buf_version }}
+        run: buf lint cre
 
       - name: Run buf breaking for cre
         if: steps.changes.outputs.cre_changed == 'true'
-        uses: bufbuild/buf-action@c231a1aa9281e5db706c970f468f0744a37561fd # v1
-        with:
-          input: cre
-          breaking: true
-          version: ${{ steps.tool-versions.outputs.buf_version }}
-          exclude_paths: node_modules
+        run: buf breaking cre --against ".git#branch=main,subdir=cre" --exclude-path node_modules
 
       - name: Skip buf checks — no cre/ changes
         if: steps.changes.outputs.cre_changed == 'false'
         run: echo "No changes to cre/ — skipping buf lint and breaking checks."
+


### PR DESCRIPTION
Tested locally with act against breaking changes to production versions (failed), breaking changes to pre-release (pass), non-breaking changes to production (pass) and non-cre folders are ignored