### PR TITLE
modify cache settings

### DIFF
--- a/cre/capabilities/networking/http/v1alpha/client.proto
+++ b/cre/capabilities/networking/http/v1alpha/client.proto
@@ -4,10 +4,10 @@ package capabilities.networking.http.v1alpha;
 
 import "tools/generator/v1alpha/cre_metadata.proto";
 
+// CacheSettings defines cache control options for outbound HTTP requests.
 message CacheSettings {
-  bool read_from_cache = 1; // If true, attempt to read a cached response for the request.
-  bool store_in_cache = 2; // If true, store the response in cache for the given TTL.
-  int32 ttl_ms = 3; // Time-to-live for the cache entry in milliseconds.
+  bool read_from_cache = 1; // If true, attempt to read a cached response for the request
+  int32 max_age_ms = 2; // Maximum age of a cached response in milliseconds.
 }
 
 message Request {

--- a/cre/capabilities/networking/http/v1alpha/client.proto
+++ b/cre/capabilities/networking/http/v1alpha/client.proto
@@ -6,7 +6,7 @@ import "tools/generator/v1alpha/cre_metadata.proto";
 
 // CacheSettings defines cache control options for outbound HTTP requests.
 message CacheSettings {
-  bool read_from_cache = 1; // If true, attempt to read a cached response for the request
+  bool read_from_cache = 1; // If true, attempt to read a cached response for the request.
   int32 max_age_ms = 2; // Maximum age of a cached response in milliseconds.
 }
 

--- a/cre/capabilities/networking/http/v1alpha/trigger.proto
+++ b/cre/capabilities/networking/http/v1alpha/trigger.proto
@@ -20,7 +20,7 @@ message Payload {
 
 enum KeyType {
   KEY_TYPE_UNSPECIFIED = 0;
-  KEY_TYPE_ECDSA = 1;
+  KEY_TYPE_ECDSA_EVM = 1;
 }
 
 // Generic and extensible authorized signer abstraction


### PR DESCRIPTION
- all outbound HTTP requests are cached with default ttl. Therefore, removing `storeInCache` and `ttl`. This addresses a potential attack vector in the gateway cache where malicious nodes could influence caching behavior for honest nodes. This prevents malicious nodes from controlling what gets cached, only what gets read by the malicious node.
- renaming ECDSA key type to ECDSA_EVM to be more specific. 