### PR TITLE
modify cache settings to include store flag for cache param based routing

### DIFF
--- a/cre/capabilities/networking/http/v1alpha/client.proto
+++ b/cre/capabilities/networking/http/v1alpha/client.proto
@@ -2,12 +2,13 @@ syntax = "proto3";
 
 package capabilities.networking.http.v1alpha;
 
+import "google/protobuf/duration.proto";
 import "tools/generator/v1alpha/cre_metadata.proto";
 
 // CacheSettings defines cache control options for outbound HTTP requests.
 message CacheSettings {
   bool store = 1; // If true, cache the response.
-  int32 max_age_ms = 2; // Maximum age of a cached response in milliseconds. If zero, do not attempt to read from cache
+  google.protobuf.Duration max_age = 2; // Maximum age of a cached response. If zero, do not attempt to read from cache
 }
 
 message Request {
@@ -15,7 +16,7 @@ message Request {
   string method = 2;
   map<string, string> headers = 3;
   bytes body = 4;
-  int32 timeout_ms = 5;
+  google.protobuf.Duration timeout = 5; // Request timeout duration
   CacheSettings cache_settings = 6;
 }
 

--- a/cre/capabilities/networking/http/v1alpha/client.proto
+++ b/cre/capabilities/networking/http/v1alpha/client.proto
@@ -6,8 +6,8 @@ import "tools/generator/v1alpha/cre_metadata.proto";
 
 // CacheSettings defines cache control options for outbound HTTP requests.
 message CacheSettings {
-  bool read_from_cache = 1; // If true, attempt to read a cached response for the request.
-  int32 max_age_ms = 2; // Maximum age of a cached response in milliseconds.
+  bool store = 1; // If true, cache the response.
+  int32 max_age_ms = 2; // Maximum age of a cached response in milliseconds. If zero, do not attempt to read from cache
 }
 
 message Request {

--- a/cre/go/installer/pkg/embedded_gen.go
+++ b/cre/go/installer/pkg/embedded_gen.go
@@ -455,12 +455,13 @@ const networkingHttpV1alphaClientEmbedded = `syntax = "proto3";
 
 package capabilities.networking.http.v1alpha;
 
+import "google/protobuf/duration.proto";
 import "tools/generator/v1alpha/cre_metadata.proto";
 
 // CacheSettings defines cache control options for outbound HTTP requests.
 message CacheSettings {
   bool store = 1; // If true, cache the response.
-  int32 max_age_ms = 2; // Maximum age of a cached response in milliseconds. If zero, do not attempt to read from cache
+  google.protobuf.Duration max_age = 2; // Maximum age of a cached response. If zero, do not attempt to read from cache
 }
 
 message Request {
@@ -468,7 +469,7 @@ message Request {
   string method = 2;
   map<string, string> headers = 3;
   bytes body = 4;
-  int32 timeout_ms = 5;
+  google.protobuf.Duration timeout = 5; // Request timeout duration
   CacheSettings cache_settings = 6;
 }
 

--- a/cre/go/installer/pkg/embedded_gen.go
+++ b/cre/go/installer/pkg/embedded_gen.go
@@ -459,8 +459,8 @@ import "tools/generator/v1alpha/cre_metadata.proto";
 
 // CacheSettings defines cache control options for outbound HTTP requests.
 message CacheSettings {
-  bool read_from_cache = 1; // If true, attempt to read a cached response for the request.
-  int32 max_age_ms = 2; // Maximum age of a cached response in milliseconds.
+  bool store = 1; // If true, cache the response.
+  int32 max_age_ms = 2; // Maximum age of a cached response in milliseconds. If zero, do not attempt to read from cache
 }
 
 message Request {


### PR DESCRIPTION
- modify cache settings to include store flag for cache param based routing
- Store=false, MaxAgeMs=0 → do not use the gateway
- Store=true, MaxAgeMs=0 → request via gateway, cache response with system-level TTL
- Store=false, MaxAgeMs>0 → attempt gateway cache read; if miss, go direct to customer endpoint (no cache write)
- Store=true, MaxAgeMs>0 → attempt gateway cache read; if miss, go to customer endpoint and cache response with system-level TTL