### PR TITLE
Add Makefile for bridge status schema deployment

### DIFF
--- a/data-feeds/Makefile
+++ b/data-feeds/Makefile
@@ -1,0 +1,31 @@
+.PHONY: preview-staging
+preview-staging:
+	iron-flask deploy-confluent -e staging -c ./iron-flask-data-feeds.yaml --preview
+
+.PHONY: deploy-staging
+deploy-staging:
+	iron-flask deploy-confluent -e staging -c ./iron-flask-data-feeds.yaml
+
+.PHONY: destroy-staging
+destroy-staging:
+	iron-flask deploy-confluent -e staging -c ./iron-flask-data-feeds.yaml --destroy
+
+.PHONY: preview-prod
+preview-prod:
+	iron-flask deploy-confluent -e prod -c ./iron-flask-data-feeds.yaml --preview
+
+.PHONY: deploy-prod
+deploy-prod:
+	iron-flask deploy-confluent -e prod -c ./iron-flask-data-feeds.yaml
+
+.PHONY: destroy-prod
+destroy-prod:
+	iron-flask deploy-confluent -e prod -c ./iron-flask-data-feeds.yaml --destroy
+
+.PHONY: clean
+clean: ## Remove generated files
+	find . -name '*.pb.go' -delete
+
+.PHONY: generate
+generate: clean ## Generate go-proto files
+	go generate ./...


### PR DESCRIPTION
Add deployment infrastructure for data-feeds domain schemas:
- Bridge status protobuf schemas registration to Schema Registry
- Support for staging/prod environments with preview option
- Follows same pattern as workflows and svr deployments

This enables registration of bridge_status.v1.BridgeStatusEvent and related schemas to Confluent Schema Registry, resolving the 'beholder__data-feeds__messages-value' subject not found issue.