### PR TITLE
Add Aptos write reply metadata for CRE parity

### DIFF
--- a/cre/capabilities/blockchain/aptos/v1alpha/client.proto
+++ b/cre/capabilities/blockchain/aptos/v1alpha/client.proto
@@ -151,11 +151,17 @@ message WriteReportRequest {
   sdk.v1alpha.ReportResponse report = 3; // signed report from consensus
 }
 
+enum ReceiverContractExecutionStatus {
+  RECEIVER_CONTRACT_EXECUTION_STATUS_SUCCESS = 0;
+  RECEIVER_CONTRACT_EXECUTION_STATUS_REVERTED = 1;
+}
+
 message WriteReportReply {
   TxStatus tx_status = 1;
-  optional string tx_hash = 2; // transaction hash (hex string with 0x prefix)
-  optional uint64 transaction_fee = 3; // gas used in octas
-  optional string error_message = 4;
+  optional ReceiverContractExecutionStatus receiver_contract_execution_status = 2;
+  optional string tx_hash = 3; // transaction hash (hex string with 0x prefix)
+  optional uint64 transaction_fee = 4; // gas used in octas
+  optional string error_message = 5;
 }
 
 // ========== Service ==========

--- a/cre/go/installer/pkg/embedded_gen.go
+++ b/cre/go/installer/pkg/embedded_gen.go
@@ -154,11 +154,17 @@ message WriteReportRequest {
   sdk.v1alpha.ReportResponse report = 3; // signed report from consensus
 }
 
+enum ReceiverContractExecutionStatus {
+  RECEIVER_CONTRACT_EXECUTION_STATUS_SUCCESS = 0;
+  RECEIVER_CONTRACT_EXECUTION_STATUS_REVERTED = 1;
+}
+
 message WriteReportReply {
   TxStatus tx_status = 1;
-  optional string tx_hash = 2; // transaction hash (hex string with 0x prefix)
-  optional uint64 transaction_fee = 3; // gas used in octas
-  optional string error_message = 4;
+  optional ReceiverContractExecutionStatus receiver_contract_execution_status = 2;
+  optional string tx_hash = 3; // transaction hash (hex string with 0x prefix)
+  optional uint64 transaction_fee = 4; // gas used in octas
+  optional string error_message = 5;
 }
 
 // ========== Service ==========


### PR DESCRIPTION
## Summary
- add the remaining Aptos write reply metadata needed for closer CRE Aptos/EVM parity
- keep the change narrowly scoped to the Aptos write reply surface
- regenerate using the repo's pinned protobuf toolchain

## What changed
- added `receiver_contract_execution_status` to the Aptos `WriteReportReply`
- added `transaction_fee` to the Aptos `WriteReportReply`
- regenerated the Aptos protobuf outputs using the versions pinned in `.tool-versions`

## Why
The rebased Aptos local CRE write stack now classifies receiver vs forwarder failures and propagates Aptos transaction fees back through the write path. That requires the shared Aptos write reply proto to expose those fields so downstream repos can consume a typed execution status and metering data.

## Downstream consumers
- `chainlink-common`
- `cre-sdk-go`
- `chainlink-aptos`
- `capabilities`
- `chainlink`

## Testing
- regenerated Aptos protobuf outputs with the repo's pinned tool versions from `.tool-versions`
