### PR TITLE
Add org_id to WorkflowExecution proto

### DIFF
--- a/cre/capabilities/compute/confidentialworkflow/v1alpha/client.proto
+++ b/cre/capabilities/compute/confidentialworkflow/v1alpha/client.proto
@@ -28,6 +28,9 @@ message WorkflowExecution {
   // execution_id is the unique execution identifier (64 hex chars, 32 bytes).
   // Used by the enclave for runtime secret fetching from VaultDON.
   string execution_id = 6;
+  // org_id is the organization identifier for the workflow owner.
+  // Used by the enclave when fetching secrets from VaultDON with org-based ownership.
+  string org_id = 7;
 }
 
 // ConfidentialWorkflowRequest is the input provided to the confidential workflows capability.

--- a/cre/go/installer/pkg/embedded_gen.go
+++ b/cre/go/installer/pkg/embedded_gen.go
@@ -1079,6 +1079,9 @@ message WorkflowExecution {
   // execution_id is the unique execution identifier (64 hex chars, 32 bytes).
   // Used by the enclave for runtime secret fetching from VaultDON.
   string execution_id = 6;
+  // org_id is the organization identifier for the workflow owner.
+  // Used by the enclave when fetching secrets from VaultDON with org-based ownership.
+  string org_id = 7;
 }
 
 // ConfidentialWorkflowRequest is the input provided to the confidential workflows capability.


### PR DESCRIPTION
## Summary
- Adds `string org_id = 7` to `WorkflowExecution` in the confidential workflow proto
- Regenerates embedded codegen

The enclave needs org identity to forward to VaultDON when fetching secrets via the confidential relay path. Same pattern as the existing `owner` (field 5) and `execution_id` (field 6) fields.

Waterfall: chainlink-protos (this) -> chainlink-common (add OrgId to SecretsRequestParams) -> chainlink + CC