### PR TITLE
Registering job_spec messages for Beholder domain

### DIFF
--- a/.github/workflows/register-data-feeds-schemas.yaml
+++ b/.github/workflows/register-data-feeds-schemas.yaml
@@ -10,12 +10,14 @@ on:
       - "data-feeds/**/*.proto"
       - "data-feeds/chip-schemas.json"
       - "data-feeds/chip-job-spec-schemas.json"
+      - "data-feeds/beholder-job-spec-schemas.json"
   pull_request:
     paths:
       - ".github/workflows/register-data-feeds-schemas.yaml"
       - "data-feeds/**/*.proto"
       - "data-feeds/chip-schemas.json"
       - "data-feeds/chip-job-spec-schemas.json"
+      - "data-feeds/beholder-job-spec-schemas.json"
 
 jobs:
   register-schemas:
@@ -29,8 +31,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { name: data-feeds, file: chip-schemas.json }
-          - { name: job-spec,   file: chip-job-spec-schemas.json }
+          - { name: data-feeds,        file: chip-schemas.json }
+          - { name: job-spec,          file: chip-job-spec-schemas.json }
+          - { name: job-spec-beholder, file: beholder-job-spec-schemas.json }
 
     steps:
       - uses: actions/checkout@v5

--- a/data-feeds/beholder-job-spec-schemas.json
+++ b/data-feeds/beholder-job-spec-schemas.json
@@ -1,0 +1,49 @@
+{
+  "domain": "beholder__data-feeds.job-spec__messages",
+  "schemas": [
+    {
+      "entity": "job_spec.v1.OCR1OracleSpecInfo",
+      "path": "job_spec/v1/ocr1_oracle_spec_info.proto"
+    },
+    {
+      "entity": "job_spec.v1.OCR2EVMRelayConfig",
+      "path": "job_spec/v1/ocr2_evm_relay_config.proto"
+    },
+    {
+      "entity": "job_spec.v1.OCR2MedianPluginConfig",
+      "path": "job_spec/v1/ocr2_median_plugin_config.proto"
+    },
+    {
+      "entity": "job_spec.v1.OCR2OracleSpecInfo",
+      "path": "job_spec/v1/ocr2_oracle_spec_info.proto",
+      "references": [
+        {
+          "name": "job_spec/v1/ocr2_evm_relay_config.proto",
+          "entity": "job_spec.v1.OCR2EVMRelayConfig",
+          "path": "job_spec/v1/ocr2_evm_relay_config.proto"
+        },
+        {
+          "name": "job_spec/v1/ocr2_median_plugin_config.proto",
+          "entity": "job_spec.v1.OCR2MedianPluginConfig",
+          "path": "job_spec/v1/ocr2_median_plugin_config.proto"
+        }
+      ]
+    },
+    {
+      "entity": "job_spec.v1.JobSpecEvent",
+      "path": "job_spec/v1/job_spec_event.proto",
+      "references": [
+        {
+          "name": "job_spec/v1/ocr1_oracle_spec_info.proto",
+          "entity": "job_spec.v1.OCR1OracleSpecInfo",
+          "path": "job_spec/v1/ocr1_oracle_spec_info.proto"
+        },
+        {
+          "name": "job_spec/v1/ocr2_oracle_spec_info.proto",
+          "entity": "job_spec.v1.OCR2OracleSpecInfo",
+          "path": "job_spec/v1/ocr2_oracle_spec_info.proto"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What
- Added job_spec.proto schema to Beholder telemetry system
- Integrated JobSpecEvent message into both staging and production Beholder configurations
## Why
- Enable telemetry collection for job spec monitoring
- Provide comprehensive job spec data to the Beholder system
- Support monitoring of NOP reputation
See [DF-24355](https://smartcontract-it.atlassian.net/browse/DF-24355)

[DF-24355]: https://smartcontract-it.atlassian.net/browse/DF-24355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Required for: https://github.com/smartcontractkit/chainlink/pull/22123