### PR TITLE
Update gh worflow file to trigger on changes to chip `.json`

### DIFF
--- a/.github/workflows/register-workflows-schemas.yaml
+++ b/.github/workflows/register-workflows-schemas.yaml
@@ -7,10 +7,12 @@ on:
       - main
     paths:
       - ".github/workflows/register-workflows-schemas.yaml"
+      - "workflows/chip-*.json"
       - "workflows/**/*.proto"
   pull_request:
     paths:
       - ".github/workflows/register-workflows-schemas.yaml"
+      - "workflows/chip-*.json"
       - "workflows/**/*.proto"
 
 jobs:


### PR DESCRIPTION
## What

update gh workflow `.yaml`  to trigger when chip `.json` files are changed

## Why

schemas aren't registered if the chip `.json` is updated