### PR TITLE
Restructure ConfidentialWorkflow proto: move binary_url out of hash

### DIFF
--- a/cre/capabilities/compute/confidentialworkflow/v1alpha/client.proto
+++ b/cre/capabilities/compute/confidentialworkflow/v1alpha/client.proto
@@ -4,37 +4,48 @@ package capabilities.compute.confidentialworkflow.v1alpha;
 
 import "tools/generator/v1alpha/cre_metadata.proto";
 
-message SecretIdentifier {
-  string key = 1;
-  // namespace defaults to "main" when unset.
-  optional string namespace = 2;
-}
-
 // WorkflowExecution is the public data sent to the enclave.
-// Becomes ComputeRequest.PublicData after proto serialization.
+// Becomes ComputeRequest.PublicData after proto serialization, which is
+// covered by ComputeRequest.Hash() for F+1 quorum matching at the enclave.
+// All fields here must be byte-identical across workflow DON nodes.
 message WorkflowExecution {
   // workflow_id identifies the workflow to execute.
   string workflow_id = 1;
-  // binary_url is the URL from which the enclave fetches the compiled WASM binary.
-  string binary_url = 2;
   // binary_hash is the expected SHA-256 hash of the WASM binary, for integrity verification.
-  bytes binary_hash = 3;
+  bytes binary_hash = 2;
   // execute_request is a serialized sdk.v1alpha.ExecuteRequest proto.
   // Contains either a subscribe request or a trigger execution request.
-  bytes execute_request = 4;
+  bytes execute_request = 3;
   // owner is the on-chain owner address of the workflow (hex, 0x-prefixed).
   // Used by the enclave for runtime secret fetching from VaultDON.
-  string owner = 5;
+  string owner = 4;
   // execution_id is the unique execution identifier (64 hex chars, 32 bytes).
   // Used by the enclave for runtime secret fetching from VaultDON.
-  string execution_id = 6;
+  string execution_id = 5;
 }
 
 // ConfidentialWorkflowRequest is the input provided to the confidential workflows capability.
-// It combines a WorkflowExecution with secrets from VaultDON.
+// It carries a WorkflowExecution (deterministic across workflow DON nodes,
+// hashed for F+1 quorum) plus per-node-varying data that must live outside
+// the hash envelope.
 message ConfidentialWorkflowRequest {
-  repeated SecretIdentifier vault_don_secrets = 1;
-  WorkflowExecution execution = 2;
+  WorkflowExecution execution = 1;
+  // binary_url is the pre-signed CloudFront URL used by the enclave to fetch
+  // the WASM binary. The workflow node mints this URL per-execution via
+  // NodeService.DownloadArtifact and ships it alongside the WorkflowExecution.
+  //
+  // This field is deliberately on ConfidentialWorkflowRequest rather than
+  // inside WorkflowExecution: every workflow DON node mints its own URL with
+  // its own AWS signature and expiry timestamp, so the value differs across
+  // nodes. WorkflowExecution serializes into ComputeRequest.PublicData,
+  // which is covered by ComputeRequest.Hash() for F+1 quorum matching at the
+  // enclave. A per-node value inside that envelope would break quorum.
+  //
+  // The integrity anchor for the fetched bytes is execution.binary_hash,
+  // inside PublicData (and therefore signed and quorum-checked). The URL is
+  // a fetch hint; tampering with it is caught by the hash check on the
+  // returned bytes.
+  string binary_url = 2;
 }
 
 // ConfidentialWorkflowResponse is the output from the confidential workflows capability.

--- a/cre/go/installer/pkg/embedded_gen.go
+++ b/cre/go/installer/pkg/embedded_gen.go
@@ -432,37 +432,48 @@ package capabilities.compute.confidentialworkflow.v1alpha;
 
 import "tools/generator/v1alpha/cre_metadata.proto";
 
-message SecretIdentifier {
-  string key = 1;
-  // namespace defaults to "main" when unset.
-  optional string namespace = 2;
-}
-
 // WorkflowExecution is the public data sent to the enclave.
-// Becomes ComputeRequest.PublicData after proto serialization.
+// Becomes ComputeRequest.PublicData after proto serialization, which is
+// covered by ComputeRequest.Hash() for F+1 quorum matching at the enclave.
+// All fields here must be byte-identical across workflow DON nodes.
 message WorkflowExecution {
   // workflow_id identifies the workflow to execute.
   string workflow_id = 1;
-  // binary_url is the URL from which the enclave fetches the compiled WASM binary.
-  string binary_url = 2;
   // binary_hash is the expected SHA-256 hash of the WASM binary, for integrity verification.
-  bytes binary_hash = 3;
+  bytes binary_hash = 2;
   // execute_request is a serialized sdk.v1alpha.ExecuteRequest proto.
   // Contains either a subscribe request or a trigger execution request.
-  bytes execute_request = 4;
+  bytes execute_request = 3;
   // owner is the on-chain owner address of the workflow (hex, 0x-prefixed).
   // Used by the enclave for runtime secret fetching from VaultDON.
-  string owner = 5;
+  string owner = 4;
   // execution_id is the unique execution identifier (64 hex chars, 32 bytes).
   // Used by the enclave for runtime secret fetching from VaultDON.
-  string execution_id = 6;
+  string execution_id = 5;
 }
 
 // ConfidentialWorkflowRequest is the input provided to the confidential workflows capability.
-// It combines a WorkflowExecution with secrets from VaultDON.
+// It carries a WorkflowExecution (deterministic across workflow DON nodes,
+// hashed for F+1 quorum) plus per-node-varying data that must live outside
+// the hash envelope.
 message ConfidentialWorkflowRequest {
-  repeated SecretIdentifier vault_don_secrets = 1;
-  WorkflowExecution execution = 2;
+  WorkflowExecution execution = 1;
+  // binary_url is the pre-signed CloudFront URL used by the enclave to fetch
+  // the WASM binary. The workflow node mints this URL per-execution via
+  // NodeService.DownloadArtifact and ships it alongside the WorkflowExecution.
+  //
+  // This field is deliberately on ConfidentialWorkflowRequest rather than
+  // inside WorkflowExecution: every workflow DON node mints its own URL with
+  // its own AWS signature and expiry timestamp, so the value differs across
+  // nodes. WorkflowExecution serializes into ComputeRequest.PublicData,
+  // which is covered by ComputeRequest.Hash() for F+1 quorum matching at the
+  // enclave. A per-node value inside that envelope would break quorum.
+  //
+  // The integrity anchor for the fetched bytes is execution.binary_hash,
+  // inside PublicData (and therefore signed and quorum-checked). The URL is
+  // a fetch hint; tampering with it is caught by the hash check on the
+  // returned bytes.
+  string binary_url = 2;
 }
 
 // ConfidentialWorkflowResponse is the output from the confidential workflows capability.


### PR DESCRIPTION
## Why

binary_url must be per-node. Each workflow DON node mints its own
pre-signed URL with its own AWS signature and expiry timestamp. Keeping
it inside WorkflowExecution breaks F+1 quorum at the enclave because
WorkflowExecution serializes into ComputeRequest.PublicData, which is
covered by ComputeRequest.Hash().

## What

- Move binary_url from WorkflowExecution to ConfidentialWorkflowRequest
  (sibling of execution, outside the hash envelope).
- Drop unused SecretIdentifier message and vault_don_secrets field.
  Enclave fetches secrets dynamically at runtime; the host-side adapter
  already returns nil for this field.
- Renumber WorkflowExecution fields cleanly (no reserved gap) since the
  capability has no production consumers yet.

The new binary_url field carries a load-bearing comment in the proto
explaining the design constraint, the F+1 quorum implication, and the
trust model. Read that comment for full context.

## Trust model unchanged

execution.binary_hash is still inside PublicData (signed, quorum-checked)
and remains the integrity anchor for fetched WASM bytes. A tampered URL
cannot substitute tampered bytes.

## Follow-up PRs

This is the top of a chain.

- chainlink-common: regen .pb.go in pkg/capabilities/v2/actions/confidentialworkflow/
- confidential-compute: add per-node-data field on SignedComputeRequest with
  passthrough seam in framework executor (host and enclave side);
  enclave/apps/confidential-workflows/app/app.go reads URL from per-node-data;
  capability/action.go EnclaveActionInputAdapter wires the URL through; E2E
  test updated.
- chainlink: confidential_module.go populates new binary_url on
  ConfidentialWorkflowRequest instead of WorkflowExecution.BinaryUrl.

## Note for parallel work

There is an in-flight branch tejaswi/add-orgid-to-workflow-execution
adding an org_id field to WorkflowExecution. After this PR lands, that
branch will need to rebase: org_id should land at field 6 under the new
renumbering.

See PRIV-389 for background.