### PR TITLE
node-platform: register beholder domain schemas

### DIFF
--- a/.github/workflows/register-node-platform-schemas.yaml
+++ b/.github/workflows/register-node-platform-schemas.yaml
@@ -8,10 +8,14 @@ on:
     paths:
       - ".github/workflows/register-node-platform-schemas.yaml"
       - "node-platform/**/*.proto"
+      - "node-platform/chip-schemas.json"
+      - "node-platform/beholder-schemas.json"
   pull_request:
     paths:
       - ".github/workflows/register-node-platform-schemas.yaml"
       - "node-platform/**/*.proto"
+      - "node-platform/chip-schemas.json"
+      - "node-platform/beholder-schemas.json"
 
 jobs:
   register-schemas:
@@ -20,6 +24,14 @@ jobs:
     permissions:
       id-token: write
       contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { name: node-platform, file: chip-schemas.json }
+          - { name: beholder,      file: beholder-schemas.json }
+
     steps:
       - uses: actions/checkout@v5
 
@@ -30,13 +42,13 @@ jobs:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_PUBLISH_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Register Schemas
+      - name: Register Node Platform Schemas for ${{ matrix.config.name }} domain
         uses: smartcontractkit/.github/actions/chip-schema-registration@b1bec0ae729606681897cbf7fad5d7c1d572173e  # v1.1.0
         with:
           aws-account-id: ${{ secrets.AWS_ACCOUNT_ID_ROOT }}
           aws-region: us-west-2
           chip-schema-dir: "node-platform"
-          chip-config-file-path: "node-platform/chip-schemas.json"
+          chip-config-file-path: "node-platform/${{ matrix.config.file }}"
           chip-config-host: ${{ github.ref_name == 'main' && secrets.chip_config_host_prod || secrets.chip_config_host_staging }}
           chip-config-user: ${{ secrets.chip_config_user }}
           chip-config-password: ${{ github.ref_name == 'main' && secrets.chip_config_password_prod || secrets.chip_config_password_staging }}

--- a/node-platform/beholder-schemas.json
+++ b/node-platform/beholder-schemas.json
@@ -1,0 +1,17 @@
+{
+  "domain": "beholder__node-platform__messages",
+  "schemas": [
+    {
+      "entity": "common.v1.ChainPluginConfig",
+      "path": "common/v1/chain_plugin_config.proto"
+    },
+    {
+      "entity": "common.v1.NodeBuildInfo",
+      "path": "common/v1/node_build_info.proto"
+    },
+    {
+      "entity": "common.v1.NodeJobInfo",
+      "path": "common/v1/node_job_info.proto"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `node-platform/beholder-schemas.json` to publish `ChainPluginConfig`, `NodeBuildInfo`, and `NodeJobInfo` under the `beholder__node-platform__messages` domain
- Extend `register-node-platform-schemas` workflow with a matrix to register both chip and beholder schema configs

## Related PR's 

- https://github.com/smartcontractkit/chainlink-protos/pull/278

## Schemas registered (beholder domain)
- `beholder__node-platform__messages-common.v1.ChainPluginConfig`
- `beholder__node-platform__messages-common.v1.NodeBuildInfo`
- `beholder__node-platform__messages-common.v1.NodeJobInfo`

## Test plan
- [ ] Merge to main and confirm `register-node-platform-schemas` runs for both matrix entries
- [ ] Verify schemas appear in schema registry under `beholder__node-platform__messages`


