### PR TITLE
beholder: register data-feeds and chain-capabilities schemas

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,5 +33,8 @@
 # Node Platform
 /node-platform/ @smartcontractkit/infra-nodes @smartcontractkit/op-tooling @smartcontractkit/rane
 
+# Chain Capabilities
+/chain-capabilities/ @smartcontractkit/keystone @smartcontractkit/bix-framework @smartcontractkit/op-tooling
+
 # Release changesets do not have owners
 /.changeset/**

--- a/.github/workflows/register-chain-capabilities-schemas.yaml
+++ b/.github/workflows/register-chain-capabilities-schemas.yaml
@@ -1,4 +1,4 @@
-name: register-data-feeds-schemas
+name: register-chain-capabilities-schemas
 
 on:
   workflow_dispatch:
@@ -6,20 +6,16 @@ on:
     branches:
       - main
     paths:
-      - ".github/workflows/register-data-feeds-schemas.yaml"
-      - "data-feeds/**/*.proto"
-      - "data-feeds/chip-schemas.json"
-      - "data-feeds/chip-job-spec-schemas.json"
-      - "data-feeds/beholder-job-spec-schemas.json"
-      - "data-feeds/beholder-schemas.json"
+      - ".github/workflows/register-chain-capabilities-schemas.yaml"
+      - "chain-capabilities/**/*.proto"
+      - "chain-capabilities/chip-schemas.json"
+      - "chain-capabilities/beholder-schemas.json"
   pull_request:
     paths:
-      - ".github/workflows/register-data-feeds-schemas.yaml"
-      - "data-feeds/**/*.proto"
-      - "data-feeds/chip-schemas.json"
-      - "data-feeds/chip-job-spec-schemas.json"
-      - "data-feeds/beholder-job-spec-schemas.json"
-      - "data-feeds/beholder-schemas.json"
+      - ".github/workflows/register-chain-capabilities-schemas.yaml"
+      - "chain-capabilities/**/*.proto"
+      - "chain-capabilities/chip-schemas.json"
+      - "chain-capabilities/beholder-schemas.json"
 
 jobs:
   register-schemas:
@@ -33,10 +29,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { name: data-feeds,        file: chip-schemas.json }
-          - { name: job-spec,          file: chip-job-spec-schemas.json }
-          - { name: job-spec-beholder, file: beholder-job-spec-schemas.json }
-          - { name: beholder,          file: beholder-schemas.json }
+          - { name: chain-capabilities, file: chip-schemas.json }
+          - { name: beholder,            file: beholder-schemas.json }
 
     steps:
       - uses: actions/checkout@v5
@@ -48,13 +42,13 @@ jobs:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_PUBLISH_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Register Data Feeds Schemas for ${{ matrix.config.name }} domain
-        uses: smartcontractkit/.github/actions/chip-schema-registration@b1bec0ae729606681897cbf7fad5d7c1d572173e # v1.1.0
+      - name: Register Chain Capabilities Schemas for ${{ matrix.config.name }} domain
+        uses: smartcontractkit/.github/actions/chip-schema-registration@b1bec0ae729606681897cbf7fad5d7c1d572173e  # v1.1.0
         with:
           aws-account-id: ${{ secrets.AWS_ACCOUNT_ID_ROOT }}
           aws-region: us-west-2
-          chip-schema-dir: "data-feeds"
-          chip-config-file-path: "data-feeds/${{ matrix.config.file }}"
+          chip-schema-dir: "chain-capabilities"
+          chip-config-file-path: "chain-capabilities/${{ matrix.config.file }}"
           chip-config-host: ${{ github.ref_name == 'main' && secrets.chip_config_host_prod || secrets.chip_config_host_staging }}
           chip-config-user: ${{ secrets.chip_config_user }}
           chip-config-password: ${{ github.ref_name == 'main' && secrets.chip_config_password_prod || secrets.chip_config_password_staging }}

--- a/buf.yaml
+++ b/buf.yaml
@@ -61,6 +61,7 @@ modules:
         - ENUM_VALUE_PREFIX
         - ENUM_ZERO_VALUE_SUFFIX
   - path: node-platform
+  - path: chain-capabilities
 
 lint:
   use:

--- a/chain-capabilities/beholder-schemas.json
+++ b/chain-capabilities/beholder-schemas.json
@@ -1,0 +1,38 @@
+{
+  "domain": "beholder__chain_capabilities__messages",
+  "schemas": [
+    {
+      "entity": "WriteReportInitiated",
+      "path": "evm/monitoring/write_report.proto",
+      "references": [
+        {
+          "name": "libs/monitoring/execution_context.proto",
+          "entity": "monitoring.ExecutionContext",
+          "path": "libs/monitoring/execution_context.proto"
+        }
+      ]
+    },
+    {
+      "entity": "WriteReportSuccess",
+      "path": "evm/monitoring/write_report.proto",
+      "references": [
+        {
+          "name": "libs/monitoring/execution_context.proto",
+          "entity": "monitoring.ExecutionContext",
+          "path": "libs/monitoring/execution_context.proto"
+        }
+      ]
+    },
+    {
+      "entity": "WriteReportError",
+      "path": "evm/monitoring/write_report.proto",
+      "references": [
+        {
+          "name": "libs/monitoring/execution_context.proto",
+          "entity": "monitoring.ExecutionContext",
+          "path": "libs/monitoring/execution_context.proto"
+        }
+      ]
+    }
+  ]
+}

--- a/chain-capabilities/chip-schemas.json
+++ b/chain-capabilities/chip-schemas.json
@@ -1,0 +1,38 @@
+{
+  "domain": "chain-capabilities",
+  "schemas": [
+    {
+      "entity": "WriteReportInitiated",
+      "path": "evm/monitoring/write_report.proto",
+      "references": [
+        {
+          "name": "libs/monitoring/execution_context.proto",
+          "entity": "monitoring.ExecutionContext",
+          "path": "libs/monitoring/execution_context.proto"
+        }
+      ]
+    },
+    {
+      "entity": "WriteReportSuccess",
+      "path": "evm/monitoring/write_report.proto",
+      "references": [
+        {
+          "name": "libs/monitoring/execution_context.proto",
+          "entity": "monitoring.ExecutionContext",
+          "path": "libs/monitoring/execution_context.proto"
+        }
+      ]
+    },
+    {
+      "entity": "WriteReportError",
+      "path": "evm/monitoring/write_report.proto",
+      "references": [
+        {
+          "name": "libs/monitoring/execution_context.proto",
+          "entity": "monitoring.ExecutionContext",
+          "path": "libs/monitoring/execution_context.proto"
+        }
+      ]
+    }
+  ]
+}

--- a/chain-capabilities/evm/monitoring/write_report.proto
+++ b/chain-capabilities/evm/monitoring/write_report.proto
@@ -1,0 +1,57 @@
+// Copied from https://github.com/smartcontractkit/capabilities/blob/main/chain_capabilities/evm/monitoring/write_report.proto
+syntax = "proto3";
+
+package chain_capabilities.evm;
+
+option go_package = "github.com/smartcontractkit/chainlink-protos/chain-capabilities/evm/monitoring";
+
+import "libs/monitoring/execution_context.proto";
+
+message WriteReportInitiated {
+  WriteReportRequest req = 1;
+  monitoring.ExecutionContext execution_context = 20;
+}
+
+message WriteReportSuccess {
+  WriteReportRequest req = 1;
+  int32 log_count = 2;
+  monitoring.ExecutionContext execution_context = 20;
+}
+
+message WriteReportError {
+  WriteReportRequest req = 1;
+  string summary = 2;
+  string cause = 3;
+  monitoring.ExecutionContext execution_context = 20;
+}
+
+message WriteReportTxFeeCalculationError {
+  WriteReportRequest req = 1;
+  string summary = 2;
+  string cause = 3;
+  string tx_idempotency_key = 4;
+  monitoring.ExecutionContext execution_context = 20;
+}
+
+message WriteReportRequest {
+  bytes receiver = 1;
+  ReportResponse report = 2;
+  optional GasConfig gas_config = 3;
+}
+
+message GasConfig {
+  uint64 gas_limit = 1;
+}
+
+message ReportResponse {
+  bytes config_digest = 1;
+  uint64 seq_nr = 2;
+  bytes report_context = 3; // combination of seq_nr and config_digest
+  bytes raw_report = 4;
+  repeated AttributedSignature sigs = 5;
+}
+
+message AttributedSignature {
+  bytes signature = 1;
+  uint32 signer_id = 2;
+}

--- a/chain-capabilities/libs/monitoring/execution_context.proto
+++ b/chain-capabilities/libs/monitoring/execution_context.proto
@@ -1,0 +1,33 @@
+// Copied from https://github.com/smartcontractkit/capabilities/blob/main/libs/monitoring/execution_context.proto
+syntax = "proto3";
+
+package monitoring;
+
+option go_package = "github.com/smartcontractkit/chainlink-protos/chain-capabilities/libs/monitoring";
+
+// [Execution Context]
+message ExecutionContext {
+  // Execution Context - Source
+  string meta_source_id = 1;
+
+  // Execution Context - Chain
+  string meta_chain_family_name = 2;
+  string meta_chain_id = 3;
+  string meta_network_name = 4;
+  string meta_network_name_full = 5;
+
+  // Execution Context - Workflow (capabilities.RequestMetadata)
+  string meta_workflow_id = 6;
+  string meta_workflow_owner = 7;
+  string meta_workflow_execution_id = 8;
+  string meta_workflow_name = 9;
+  uint32 meta_workflow_don_id = 10;
+  uint32 meta_workflow_don_config_version = 11;
+  string meta_reference_id = 12;
+
+  // Execution Context - Capability
+  string meta_capability_type = 13;
+  string meta_capability_id = 14;
+  uint64 meta_capability_timestamp_start = 15;
+  uint64 meta_capability_timestamp_emit = 16;
+}

--- a/data-feeds/beholder-schemas.json
+++ b/data-feeds/beholder-schemas.json
@@ -1,0 +1,9 @@
+{
+  "domain": "beholder__data_feeds__messages",
+  "schemas": [
+    {
+      "entity": "data_feeds.on_chain.registry.FeedUpdated",
+      "path": "on_chain/registry/feed_updated.proto"
+    }
+  ]
+}

--- a/data-feeds/chip-schemas.json
+++ b/data-feeds/chip-schemas.json
@@ -51,6 +51,10 @@
           "path": "bridge_status/v1/configuration_item.proto"
         }
       ]
+    },
+    {
+      "entity": "data_feeds.on_chain.registry.FeedUpdated",
+      "path": "on_chain/registry/feed_updated.proto"
     }
   ]
 }

--- a/data-feeds/on_chain/registry/feed_updated.proto
+++ b/data-feeds/on_chain/registry/feed_updated.proto
@@ -1,0 +1,61 @@
+// Copied from https://github.com/smartcontractkit/atlas/blob/main/schemas/atlas/proto/beholder/data-feeds/feed_updated.proto
+syntax = "proto3";
+
+package data_feeds.on_chain.registry;
+
+option go_package = "github.com/smartcontractkit/chainlink-protos/data-feeds/on_chain/registry";
+
+// The on-chain FeedUpdated event which is extracted from the tx/event data or
+// the write-target WriteConfirmed event, after a write was confirmed (@see message: write-target.WriteConfirmed).
+message FeedUpdated {
+  // Event data
+  string feed_id = 1; // bytes as hex string for readability
+  uint32 observations_timestamp = 2;
+  bytes benchmark = 3;
+  bytes report = 4;
+
+  // Notice: benchmark_val is the benchmark i192 on-chain value decoded as an double (float64), scaled by number of decimals (e.g., 1e-18)
+  // This is the largest type Prometheus supports, and this conversion can overflow but so far was sufficient
+  // for most use-cases. For big numbers, benchmark bytes should be used instead.
+  //
+  // Set as `math.NaN()` if report data type not a number, or `+/-Inf` if number doesn't fit in double.
+  double benchmark_val = 5;
+
+  // Head data - when was the event produced on-chain
+  string block_hash = 6;
+  string block_height = 7;
+  uint64 block_timestamp = 8;
+
+  // Transaction data - info about the tx that mained the event (optional)
+  string tx_id = 10; // TXM ref
+  string tx_hash = 11;
+  string tx_sender = 12;
+  string tx_receiver = 13;
+  string tx_status = 14;
+
+  // [Execution Context]
+  // TODO: replace with a proto reference once supported
+  // Execution Context - Source
+  string meta_source_id = 20;
+
+  // Execution Context - Chain
+  string meta_chain_family_name = 21;
+  string meta_chain_id = 22;
+  string meta_network_name = 23;
+  string meta_network_name_full = 24;
+
+  // Execution Context - Workflow (capabilities.RequestMetadata)
+  string meta_workflow_id = 25;
+  string meta_workflow_owner = 26;
+  string meta_workflow_execution_id = 27;
+  string meta_workflow_name = 28;
+  uint32 meta_workflow_don_id = 29;
+  uint32 meta_workflow_don_config_version = 30;
+  string meta_reference_id = 31;
+
+  // Execution Context - Capability
+  string meta_capability_type = 32;
+  string meta_capability_id = 33;
+  uint64 meta_capability_timestamp_start = 34;
+  uint64 meta_capability_timestamp_emit = 35;
+}


### PR DESCRIPTION
## Summary
- Register `data_feeds.on_chain.registry.FeedUpdated` under `beholder__data_feeds__messages`
- Register `WriteReportInitiated`, `WriteReportSuccess`, and `WriteReportError` under `beholder__chain_capabilities__messages`
- Add schema registration workflows for the new beholder configs

## Missing schemas addressed
| Subject | Domain |
|---------|--------|
| `beholder__data_feeds__messages-data_feeds.on_chain.registry.FeedUpdated` | data_feeds |
| `beholder__chain_capabilities__messages-WriteReportInitiated` | chain_capabilities |
| `beholder__chain_capabilities__messages-WriteReportSuccess` | chain_capabilities |
| `beholder__chain_capabilities__messages-WriteReportError` | chain_capabilities |

## Changes
- `data-feeds/on_chain/registry/feed_updated.proto` + `data-feeds/beholder-schemas.json`
- `chain-capabilities/evm/monitoring/write_report.proto` + `chain-capabilities/libs/monitoring/execution_context.proto` + `chain-capabilities/beholder-schemas.json`
- Extend `register-data-feeds-schemas` matrix; add `register-chain-capabilities-schemas` workflow

## Safety

Ensure topics exist in shared-stage, shared-prod RP clusters: 

- beholder__chain_capabilities__messages
- beholder__data_feeds__messages

## Test plan
- [ ] Merge to main and confirm both registration workflows run successfully
- [ ] Verify the four schema subjects appear in schema registry
- [ ] Confirm `beholder_kafka_missing_schema` counts drop for these entities in prod


Made with [Cursor](https://cursor.com)