### PR TITLE
Move binary_url back into the hash; deprecate the outside-envelope field

### DIFF
--- a/cre/capabilities/compute/confidentialworkflow/v1alpha/client.proto
+++ b/cre/capabilities/compute/confidentialworkflow/v1alpha/client.proto
@@ -18,10 +18,12 @@ message SecretIdentifier {
 message WorkflowExecution {
   // workflow_id identifies the workflow to execute.
   string workflow_id = 1;
-  // binary_url is retained for backward compatibility with existing consumers.
-  // New consumers must use ConfidentialWorkflowRequest.binary_url, which lives
-  // outside the hash envelope so each node can mint its own per-node URL
-  // without breaking F+1 quorum. See ConfidentialWorkflowRequest.binary_url.
+  // binary_url is the URL from which the enclave fetches the compiled WASM
+  // binary. It lives inside WorkflowExecution (PublicData), covered by
+  // ComputeRequest.Hash() for F+1 quorum, so every node agrees on the same
+  // canonical locator. Authentication to the storage service is handled out of
+  // band by the fetch sidecar, so this is a stable, node-agnostic locator
+  // rather than a per-node pre-signed URL.
   string binary_url = 2;
   // binary_hash is the expected SHA-256 hash of the WASM binary, for integrity verification.
   bytes binary_hash = 3;
@@ -49,22 +51,19 @@ message WorkflowExecution {
 }
 
 // ConfidentialWorkflowRequest is the input provided to the confidential workflows capability.
-// It combines a WorkflowExecution with secrets from VaultDON.
+// It carries a WorkflowExecution; the enclave fetches any secrets dynamically
+// at runtime via the relay DON.
 message ConfidentialWorkflowRequest {
-  repeated SecretIdentifier vault_don_secrets = 1;
+  // Deprecated: secrets are fetched dynamically by the enclave at runtime via
+  // the relay DON, not declared up front on the request. Retained for
+  // back-compat; no longer populated.
+  repeated SecretIdentifier vault_don_secrets = 1 [deprecated = true];
   WorkflowExecution execution = 2;
-  // binary_url is the pre-signed URL used by the enclave to fetch the WASM
-  // binary. It lives here, on ConfidentialWorkflowRequest, rather than inside
-  // WorkflowExecution: every workflow DON node mints its own URL with its own
-  // signature and expiry timestamp, so the value differs across nodes.
-  // WorkflowExecution serializes into ComputeRequest.PublicData, which is
-  // covered by ComputeRequest.Hash() for F+1 quorum matching at the enclave.
-  // A per-node value inside that envelope would break quorum.
-  //
-  // The integrity anchor for the fetched bytes is execution.binary_hash, inside
-  // PublicData (and therefore signed and quorum-checked). The URL is a fetch
-  // hint; tampering with it is caught by the hash check on the returned bytes.
-  string binary_url = 3;
+  // Deprecated: the per-node pre-signed URL approach is superseded. binary_url
+  // now travels inside WorkflowExecution (PublicData) as a canonical locator,
+  // with authentication to the storage service handled out of band by the fetch
+  // sidecar. Retained for back-compat; no longer populated.
+  string binary_url = 3 [deprecated = true];
 }
 
 // ConfidentialWorkflowResponse is the output from the confidential workflows capability.

--- a/cre/capabilities/compute/confidentialworkflow/v1alpha/client.proto
+++ b/cre/capabilities/compute/confidentialworkflow/v1alpha/client.proto
@@ -51,13 +51,9 @@ message WorkflowExecution {
 }
 
 // ConfidentialWorkflowRequest is the input provided to the confidential workflows capability.
-// It carries a WorkflowExecution; the enclave fetches any secrets dynamically
-// at runtime via the relay DON.
+// It combines a WorkflowExecution with secrets from VaultDON.
 message ConfidentialWorkflowRequest {
-  // Deprecated: secrets are fetched dynamically by the enclave at runtime via
-  // the relay DON, not declared up front on the request. Retained for
-  // back-compat; no longer populated.
-  repeated SecretIdentifier vault_don_secrets = 1 [deprecated = true];
+  repeated SecretIdentifier vault_don_secrets = 1;
   WorkflowExecution execution = 2;
   // Deprecated: the per-node pre-signed URL approach is superseded. binary_url
   // now travels inside WorkflowExecution (PublicData) as a canonical locator,

--- a/cre/go/installer/pkg/embedded_gen.go
+++ b/cre/go/installer/pkg/embedded_gen.go
@@ -1379,10 +1379,12 @@ message SecretIdentifier {
 message WorkflowExecution {
   // workflow_id identifies the workflow to execute.
   string workflow_id = 1;
-  // binary_url is retained for backward compatibility with existing consumers.
-  // New consumers must use ConfidentialWorkflowRequest.binary_url, which lives
-  // outside the hash envelope so each node can mint its own per-node URL
-  // without breaking F+1 quorum. See ConfidentialWorkflowRequest.binary_url.
+  // binary_url is the URL from which the enclave fetches the compiled WASM
+  // binary. It lives inside WorkflowExecution (PublicData), covered by
+  // ComputeRequest.Hash() for F+1 quorum, so every node agrees on the same
+  // canonical locator. Authentication to the storage service is handled out of
+  // band by the fetch sidecar, so this is a stable, node-agnostic locator
+  // rather than a per-node pre-signed URL.
   string binary_url = 2;
   // binary_hash is the expected SHA-256 hash of the WASM binary, for integrity verification.
   bytes binary_hash = 3;
@@ -1414,18 +1416,11 @@ message WorkflowExecution {
 message ConfidentialWorkflowRequest {
   repeated SecretIdentifier vault_don_secrets = 1;
   WorkflowExecution execution = 2;
-  // binary_url is the pre-signed URL used by the enclave to fetch the WASM
-  // binary. It lives here, on ConfidentialWorkflowRequest, rather than inside
-  // WorkflowExecution: every workflow DON node mints its own URL with its own
-  // signature and expiry timestamp, so the value differs across nodes.
-  // WorkflowExecution serializes into ComputeRequest.PublicData, which is
-  // covered by ComputeRequest.Hash() for F+1 quorum matching at the enclave.
-  // A per-node value inside that envelope would break quorum.
-  //
-  // The integrity anchor for the fetched bytes is execution.binary_hash, inside
-  // PublicData (and therefore signed and quorum-checked). The URL is a fetch
-  // hint; tampering with it is caught by the hash check on the returned bytes.
-  string binary_url = 3;
+  // Deprecated: the per-node pre-signed URL approach is superseded. binary_url
+  // now travels inside WorkflowExecution (PublicData) as a canonical locator,
+  // with authentication to the storage service handled out of band by the fetch
+  // sidecar. Retained for back-compat; no longer populated.
+  string binary_url = 3 [deprecated = true];
 }
 
 // ConfidentialWorkflowResponse is the output from the confidential workflows capability.


### PR DESCRIPTION
Pivots the confidential-workflows binary fetch away from per-node pre-signed URLs.

`binary_url` returns to `WorkflowExecution` (inside `PublicData`, covered by
`ComputeRequest.Hash()`) as a stable, node-agnostic canonical locator. The
enclave will authenticate to the storage service out of band via a fetch
sidecar, so per-node URLs are no longer needed and the value can live inside
the hash envelope again.

- `WorkflowExecution.binary_url`: restored as the canonical field (was
  comment-deprecated by #376).
- `ConfidentialWorkflowRequest.binary_url`: deprecated (`[deprecated = true]`),
  kept for back-compat, no longer populated.

Proto-only, additive (no field removed or renumbered), so no Go API break.
Downstream: chainlink-common regen + bump, then chainlink/core and
confidential-compute. PRs #22590 and CC #343 are being reworked on top of this.
