### PR TITLE
chore(ci): migrate to setup-github-token

### DIFF
--- a/.github/workflows/cre-validations.yml
+++ b/.github/workflows/cre-validations.yml
@@ -67,21 +67,14 @@ jobs:
     outputs:
       commit_made: ${{ steps.auto-fix-completed.outputs.commit_made || steps.no-changes.outputs.commit_made }}
     steps:
-      - name: Assume aws gati role
-        if: github.actor != 'app-token-issuer-engops[bot]'
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-        with:
-          role-to-assume: ${{ secrets.AWS_IAM_ROLE_ARN_GATI }}
-          role-duration-seconds: 900
-          aws-region: ${{ secrets.AWS_REGION }}
-          mask-aws-account-id: true
-
-      - name: Get github token from gati
+      - name: Setup Github Token
         id: get-gh-token
         if: github.actor != 'app-token-issuer-engops[bot]'
-        uses: smartcontractkit/chainlink-github-actions/github-app-token-issuer@main
+        uses: smartcontractkit/.github/actions/setup-github-token@setup-github-token/v1
         with:
-          url: ${{ secrets.AWS_LAMBDA_URL_GATI }}
+          aws-role-arn: ${{ secrets.AWS_IAM_ROLE_ARN_GATI }}
+          aws-lambda-url: ${{ secrets.AWS_LAMBDA_URL_GATI }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         if: github.actor != 'app-token-issuer-engops[bot]'

--- a/.github/workflows/regenerate-protobuf.yml
+++ b/.github/workflows/regenerate-protobuf.yml
@@ -97,21 +97,14 @@ jobs:
     needs: [buf, changes]
     if: ${{ needs.changes.outputs.relevant == 'true' && always() && needs.buf.result != 'cancelled' }}
     steps:
-      - name: Assume aws gati role
-        if: github.actor != 'app-token-issuer-engops[bot]'
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-        with:
-          role-to-assume: ${{ secrets.AWS_IAM_ROLE_ARN_GATI }}
-          role-duration-seconds: 900
-          aws-region: ${{ secrets.AWS_REGION }}
-          mask-aws-account-id: true
-
-      - name: Get github token from gati
+      - name: Setup Github Token
         id: get-gh-token
         if: github.actor != 'app-token-issuer-engops[bot]'
-        uses: smartcontractkit/chainlink-github-actions/github-app-token-issuer@main
+        uses: smartcontractkit/.github/actions/setup-github-token@setup-github-token/v1
         with:
-          url: ${{ secrets.AWS_LAMBDA_URL_GATI }}
+          aws-role-arn: ${{ secrets.AWS_IAM_ROLE_ARN_GATI }}
+          aws-lambda-url: ${{ secrets.AWS_LAMBDA_URL_GATI }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Checkout repo
         if: github.actor != 'app-token-issuer-engops[bot]'


### PR DESCRIPTION
Migrates from `smartcontractkit/chainlink-github-actions/github-app-token-issuer` to `smartcontractkit/.github/actions/setup-github-token`.

### Motivation

* `/chainlink-github-actions` repo is dead and should not be referenced.

### Testing

Let this PR's CI run these workflows
* https://github.com/smartcontractkit/chainlink-protos/actions/runs/27038331505/job/79807872525?pr=395#step:3:31
* https://github.com/smartcontractkit/chainlink-protos/actions/runs/27038331457/job/79807966316?pr=395#step:4:31

---

DX-3782